### PR TITLE
Update SclParser.java

### DIFF
--- a/src/main/java/com/beanit/openiec61850/SclParser.java
+++ b/src/main/java/com/beanit/openiec61850/SclParser.java
@@ -199,6 +199,8 @@ public class SclParser {
     }
 
     ServerModel serverModel = new ServerModel(logicalDevices, null);
+    
+    dataSetMap.clear();
 
     for (LnSubDef dataSetDef : dataSetDefs) {
       DataSet dataSet = createDataSet(serverModel, dataSetDef.logicalNode, dataSetDef.defXmlNode);
@@ -206,6 +208,8 @@ public class SclParser {
     }
 
     serverModel.addDataSets(dataSetsMap.values());
+    
+    dataSetDefs.clear();
 
     return serverModel;
   }


### PR DESCRIPTION
The library has a problem of importing a whole SCD file which consists of several IEDs and that is because The dataSets Map is not cleared between switching of creating the next ServerModel of next IED.